### PR TITLE
feat: move MTA-STS policy to enforce for live test

### DIFF
--- a/.well-known/mta-sts.txt
+++ b/.well-known/mta-sts.txt
@@ -1,4 +1,4 @@
 version: STSv1
-mode: testing
+mode: enforce
 mx: jlwav-com.mail.protection.outlook.com
-max_age: 604800
+max_age: 86400


### PR DESCRIPTION
This sets mode to 'enforce' with a 1-day max_age to evaluate compatibility with common senders like ProtonMail and iCloud. Will revert to 'testing' after confirming behavior.